### PR TITLE
Feature/Upgrade process dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   file: ^5.0.7
   archive: ^2.0.9
   platform: ^2.2.0
-  process: ^3.0.9
+  process: ^4.1.0
   meta: ^1.1.6
   intl: ">=0.15.0 <1.0.0"
   tool_mobile: ^1.9.5


### PR DESCRIPTION
Because screenshots >=1.0.0 depends on process ^3.0.9 and every version of flutter_driver from sdk depends on process 4.0.0, screenshots >=1.0.0 is incompatible with flutter_driver from sdk.
So, because flutter_image_to_text_app depends on both flutter_driver any from sdk and screenshots ^2.1.1, version solving failed.
pub get failed (1; So, because flutter_image_to_text_app depends on both flutter_driver any from sdk and screenshots ^2.1.1, version solving failed.)